### PR TITLE
Feat/orderbox : post 요청 구현, post 성공유무에 따라 장바구니 주문 목록 저장 가능

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,31 @@
 import { Routes, Route } from "react-router-dom";
-import { useRecoilValue } from "recoil";
 
 import Home from "./screen/Home/Home";
 import Order from "./screen/Order/Order";
+import Result from "./screen/Result/Result";
 
+import check from "./asset/images/CheckFilled.svg";
 import styles from "./App.module.css";
 
-import { cartState } from "./recoil/atoms/cartState";
+const complete = {
+  url: check,
+  firstRow: "주문이 완료되었습니다.",
+  secondRow: "",
+};
+const error = {
+  url: null,
+  firstRow: "주문에 실패하였습니다.",
+  secondRow: "다시 시도해주세요.",
+};
 
 function App() {
-  const cart = useRecoilValue(cartState);
-
   return (
     <div className={styles.container}>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/order" element={<Order />} />
-        <Route path="/complete" element={<div>성공</div>} />
-        <Route path="/error" element={<div>에러</div>} />
+        <Route path="/complete" element={<Result info={complete} />} />
+        <Route path="/error" element={<Result info={error} />} />
         <Route path="*" element={<div>유효하지않은 경로</div>} />
       </Routes>
     </div>

--- a/src/api/postData.js
+++ b/src/api/postData.js
@@ -1,3 +1,14 @@
 const API_KEY = "http://localhost:3001";
 
-export const postData = () => {};
+export const postData = async (payload) => {
+  const requestOptions = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  };
+  const response = await fetch(`${API_KEY}/order`, requestOptions);
+  const data = response.json();
+  return data;
+};

--- a/src/api/postData.js
+++ b/src/api/postData.js
@@ -1,0 +1,3 @@
+const API_KEY = "http://localhost:3001";
+
+export const postData = () => {};

--- a/src/components/OrderBox/OrderBox.jsx
+++ b/src/components/OrderBox/OrderBox.jsx
@@ -1,10 +1,29 @@
-import { convertCartState } from "../../recoil/selectors/convertCartState";
+import { useMutation } from "@tanstack/react-query";
 import { useRecoilValue } from "recoil";
+import { convertCartState } from "../../recoil/selectors/convertCartState";
+import { cartState } from "../../recoil/atoms/cartState";
+
+import { postData } from "../../api/postData";
 
 import styles from "./OrderBox.module.css";
 
 export default function OrderBox({ isPending }) {
   const cartItem = useRecoilValue(convertCartState);
+  const orderData = useRecoilValue(cartState);
+
+  const orderMutation = useMutation({
+    mutationFn: () => postData(orderData.items),
+    onSuccess: () => {
+      console.log("요청 성공");
+    },
+    onError: () => {
+      console.error("에러 발생");
+    },
+  });
+
+  const orderButtonHandler = () => {
+    orderMutation.mutate(cartItem.items);
+  };
 
   return (
     <div className={styles.container}>
@@ -19,7 +38,12 @@ export default function OrderBox({ isPending }) {
         </p>
       </div>
       <div className={styles.buttonContainer}>
-        <button disabled={isPending || !cartItem.totalAmount}>주문하기</button>
+        <button
+          onClick={orderButtonHandler}
+          disabled={isPending || !cartItem.totalAmount}
+        >
+          주문하기
+        </button>
       </div>
     </div>
   );

--- a/src/components/OrderBox/OrderBox.jsx
+++ b/src/components/OrderBox/OrderBox.jsx
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useRecoilValue } from "recoil";
 import { convertCartState } from "../../recoil/selectors/convertCartState";
 import { cartState } from "../../recoil/atoms/cartState";
+import { useNavigate } from "react-router-dom";
 
 import { postData } from "../../api/postData";
 
@@ -11,13 +12,15 @@ export default function OrderBox({ isPending }) {
   const cartItem = useRecoilValue(convertCartState);
   const orderData = useRecoilValue(cartState);
 
+  const navigate = useNavigate();
+
   const orderMutation = useMutation({
     mutationFn: () => postData(orderData.items),
     onSuccess: () => {
-      console.log("요청 성공");
+      navigate("/complete");
     },
     onError: () => {
-      console.error("에러 발생");
+      navigate("/error");
     },
   });
 

--- a/src/components/itemCard/ItemCard.jsx
+++ b/src/components/itemCard/ItemCard.jsx
@@ -3,6 +3,12 @@ import { cartState } from "../../recoil/atoms/cartState";
 import { useRecoilState } from "recoil";
 
 import numberToKorean from "../../util/numberToKorean";
+import {
+  updateCart,
+  removeFromCart,
+  decreaseQuantity,
+  increaseQuantity,
+} from "../../util/cartUtils";
 
 import styles from "./ItemCard.module.css";
 
@@ -19,55 +25,18 @@ export default function ItemCard({ item }) {
   const findItemIndex = () =>
     cartItem.items.findIndex((cartItem) => cartItem.id === id);
 
-  const updateCart = (amount, totalPrice) => {
-    setCartItem((prev) => ({
-      ...prev,
-      totalAmount: prev.totalAmount + amount,
-      totalPrice: prev.totalPrice + totalPrice,
-    }));
-  };
-
-  const removeFromCart = (itemIndex) => {
-    setCartItem((prev) => ({
-      ...prev,
-      items: prev.items.filter((cartItem, index) => index !== itemIndex),
-    }));
-  };
-
-  const decreaseQuantity = (itemIndex) => {
-    setCartItem((prev) => {
-      const updatedItems = [...prev.items];
-      updatedItems[itemIndex] = {
-        ...updatedItems[itemIndex],
-        quantity: updatedItems[itemIndex].quantity - 1,
-      };
-      return { ...prev, items: updatedItems };
-    });
-  };
-
-  const increaseQuantity = (itemIndex) => {
-    setCartItem((prev) => {
-      const updatedItems = [...prev.items];
-      updatedItems[itemIndex] = {
-        ...updatedItems[itemIndex],
-        quantity: updatedItems[itemIndex].quantity + 1,
-      };
-      return { ...prev, items: updatedItems };
-    });
-  };
-
   const decreaseCount = () => {
     if (itemCount > MIN_QUANTITY) {
       const itemIndex = findItemIndex();
       const currentQuantity = cartItem.items[itemIndex].quantity;
 
       if (currentQuantity === DEFAULT_QUANTITY) {
-        removeFromCart(itemIndex);
+        removeFromCart(setCartItem, itemIndex);
       } else {
-        decreaseQuantity(itemIndex);
+        decreaseQuantity(setCartItem, itemIndex);
       }
 
-      updateCart(-1, -price);
+      updateCart(setCartItem, -1, -price);
       setItemCount((prevCount) => prevCount - 1);
     }
   };
@@ -85,11 +54,11 @@ export default function ItemCard({ item }) {
           ],
         }));
       } else {
-        increaseQuantity(itemIndex);
+        increaseQuantity(setCartItem, itemIndex);
       }
 
       setItemCount((prevCount) => prevCount + 1);
-      updateCart(1, price);
+      updateCart(setCartItem, 1, price);
     }
   };
 

--- a/src/db/db.json
+++ b/src/db/db.json
@@ -77,5 +77,6 @@
       "materialType": 1,
       "price": 80000
     }
-  ]
+  ],
+  "order": []
 }

--- a/src/recoil/atoms/cartState.js
+++ b/src/recoil/atoms/cartState.js
@@ -2,5 +2,5 @@ import { atom } from "recoil";
 
 export const cartState = atom({
   key: "cartState",
-  default: { totalAmount: 0, totalPrice: 0 },
+  default: { totalAmount: 0, totalPrice: 0, items: [] },
 });

--- a/src/screen/Loading/Loading.jsx
+++ b/src/screen/Loading/Loading.jsx
@@ -1,0 +1,11 @@
+import styles from "./Loading.module.css";
+
+export default function Loading({ url = null, firstRow = "", secondRow = "" }) {
+  return (
+    <div className={styles.container}>
+      <img className={!url && styles.none} src={url} alt="icon" />
+      <p>{firstRow}</p>
+      <p>{secondRow}</p>
+    </div>
+  );
+}

--- a/src/screen/Loading/Loading.module.css
+++ b/src/screen/Loading/Loading.module.css
@@ -1,0 +1,15 @@
+.container {
+  font-size: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container > img {
+  width: 48px;
+  height: 48px;
+}
+
+.none {
+  display: none;
+}

--- a/src/screen/Order/Order.jsx
+++ b/src/screen/Order/Order.jsx
@@ -1,7 +1,7 @@
 import Header from "../../components/Header/Header";
 import List from "../../components/List/List";
 import OrderBox from "../../components/OrderBox/OrderBox";
-import Result from "../Result/Result";
+import Loading from "../Loading/Loading";
 
 import { fetchData } from "../../api/fetchData";
 import { useQuery } from "@tanstack/react-query";
@@ -17,7 +17,7 @@ export default function Order() {
   const renderContent = () => {
     if (isPending) {
       return (
-        <Result
+        <Loading
           url={null}
           firstRow={"목록을"}
           secondRow={"불러오고 있습니다."}

--- a/src/screen/Result/Result.jsx
+++ b/src/screen/Result/Result.jsx
@@ -1,11 +1,36 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useResetRecoilState } from "recoil";
+import { cartState } from "../../recoil/atoms/cartState";
+
 import styles from "./Result.module.css";
 
-export default function Result({ url = null, firstRow = "", secondRow = "" }) {
+export default function Result({ info }) {
+  const navigate = useNavigate();
+  const [progress, setProgress] = useState(100);
+  const resetCartState = useResetRecoilState(cartState);
+
+  useEffect(() => {
+    const redirectTimer = setTimeout(() => {
+      resetCartState();
+      navigate("/order");
+    }, 3000);
+
+    const interval = setInterval(() => {
+      setProgress((prevProgress) => Math.max(0, prevProgress - 1));
+    }, 30);
+
+    return () => {
+      clearInterval(interval);
+      clearTimeout(redirectTimer);
+    };
+  }, [navigate, resetCartState]);
   return (
     <div className={styles.container}>
-      <img className={!url && styles.none} src={url} alt="icon" />
-      <p>{firstRow}</p>
-      <p>{secondRow}</p>
+      <img className={!info.url && styles.none} src={info.url} alt="icon" />
+      <p>{info.firstRow}</p>
+      <p>{info.secondRow}</p>
+      <progress value={progress} max="100" />
     </div>
   );
 }

--- a/src/util/cartUtils.js
+++ b/src/util/cartUtils.js
@@ -1,0 +1,36 @@
+export const updateCart = (setCartItem, amount, totalPrice) => {
+  setCartItem((prev) => ({
+    ...prev,
+    totalAmount: prev.totalAmount + amount,
+    totalPrice: prev.totalPrice + totalPrice,
+  }));
+};
+
+export const removeFromCart = (setCartItem, itemIndex) => {
+  setCartItem((prev) => ({
+    ...prev,
+    items: prev.items.filter((cartItem, index) => index !== itemIndex),
+  }));
+};
+
+export const decreaseQuantity = (setCartItem, itemIndex) => {
+  setCartItem((prev) => {
+    const updatedItems = [...prev.items];
+    updatedItems[itemIndex] = {
+      ...updatedItems[itemIndex],
+      quantity: updatedItems[itemIndex].quantity - 1,
+    };
+    return { ...prev, items: updatedItems };
+  });
+};
+
+export const increaseQuantity = (setCartItem, itemIndex) => {
+  setCartItem((prev) => {
+    const updatedItems = [...prev.items];
+    updatedItems[itemIndex] = {
+      ...updatedItems[itemIndex],
+      quantity: updatedItems[itemIndex].quantity + 1,
+    };
+    return { ...prev, items: updatedItems };
+  });
+};


### PR DESCRIPTION
## 특이사항 : post 요청 추가, 3초뒤 /order로 리다이렉트 되는것을 알려주기위해 progressbar 추가

1. 주문 성공
![주문성공](https://github.com/crowcrow07/Second_CodingTest/assets/88226519/1a52c73b-3984-4be7-bff9-0ab41a66c1bd)

1-1. 주문성공시 주문목록이 저장됨
<img width="216" alt="스크린샷 2024-01-11 오전 12 22 04" src="https://github.com/crowcrow07/Second_CodingTest/assets/88226519/ecf541ad-4cef-44e1-a441-8f5947415984">

2. 주문 실패
![주문실패](https://github.com/crowcrow07/Second_CodingTest/assets/88226519/398ecdc9-6c3a-4cba-b89b-7ea02b9bf79f)
